### PR TITLE
Update helpers to modern api, demo net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ node_modules/
 
 # IDE-specific
 .vscode/
+
+# demo mnemonics from cli
+*.key

--- a/packages/cli/examples/helpers.ts
+++ b/packages/cli/examples/helpers.ts
@@ -78,7 +78,7 @@ const smartQuery = async (client: CosmWasmClient, addr: string, query: object): 
 const loadOrCreateMnemonic = (filename: string): string => {
   try {
     const mnemonic = fs.readFileSync(filename, "utf8");
-    return mnemonic;
+    return mnemonic.trim();
   } catch (err) {
     const mnemonic = Bip39.encode(Random.getBytes(16)).toString();
     fs.writeFileSync(filename, mnemonic, "utf8");

--- a/packages/cli/examples/helpers.ts
+++ b/packages/cli/examples/helpers.ts
@@ -1,8 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
-import { FeeTable } from "@cosmwasm/sdk/types/signingcosmwasmclient";
-import axios from "axios";
-import * as fs from "fs";
-
 interface Options {
   httpUrl: string;
   networkId: string;


### PR DESCRIPTION
Closes #147 

The readme works against the demo net. Please review the exisiting code in `helpers.ts`.

This is now updated README, showing go cli compatibility and connecting to other testnets.
I will address #148 based on top of this
