### PR TITLE
Export symbols BankToken and Erc20Token

### DIFF
--- a/packages/bcp/src/cosmwasmcodec.ts
+++ b/packages/bcp/src/cosmwasmcodec.ts
@@ -20,14 +20,18 @@ import { pubkeyToAddress } from "./address";
 import { Caip5 } from "./caip5";
 import { parseSignedTx } from "./decode";
 import { buildSignedTx, buildUnsignedTx } from "./encode";
-import { BankTokens, Erc20Token, nonceToAccountNumber, nonceToSequence } from "./types";
+import { BankToken, Erc20Token, nonceToAccountNumber, nonceToSequence } from "./types";
 
 export class CosmWasmCodec implements TxCodec {
   private readonly addressPrefix: string;
-  private readonly bankTokens: BankTokens;
+  private readonly bankTokens: readonly BankToken[];
   private readonly erc20Tokens: readonly Erc20Token[];
 
-  public constructor(addressPrefix: string, bankTokens: BankTokens, erc20Tokens: readonly Erc20Token[] = []) {
+  public constructor(
+    addressPrefix: string,
+    bankTokens: readonly BankToken[],
+    erc20Tokens: readonly Erc20Token[] = [],
+  ) {
     this.addressPrefix = addressPrefix;
     this.bankTokens = bankTokens;
     this.erc20Tokens = erc20Tokens;

--- a/packages/bcp/src/decode.spec.ts
+++ b/packages/bcp/src/decode.spec.ts
@@ -18,7 +18,7 @@ import {
 } from "./decode";
 import * as testdata from "./testdata.spec";
 import cosmoshub from "./testdata/cosmoshub.json";
-import { BankTokens, Erc20Token } from "./types";
+import { BankToken, Erc20Token } from "./types";
 
 const { fromBase64, fromHex } = Encoding;
 
@@ -57,7 +57,7 @@ describe("decode", () => {
     },
     gasLimit: "200000",
   };
-  const defaultTokens: BankTokens = [
+  const defaultTokens: readonly BankToken[] = [
     {
       fractionalDigits: 6,
       ticker: "ATOM",

--- a/packages/bcp/src/decode.ts
+++ b/packages/bcp/src/decode.ts
@@ -21,7 +21,7 @@ import {
 import { Decimal, Encoding } from "@iov/encoding";
 import BN from "bn.js";
 
-import { BankTokens, Erc20Token } from "./types";
+import { BankToken, Erc20Token } from "./types";
 
 const { fromBase64 } = Encoding;
 
@@ -54,7 +54,7 @@ export function decodeFullSignature(signature: types.StdSignature, nonce: number
   };
 }
 
-export function coinToDecimal(tokens: BankTokens, coin: Coin): readonly [Decimal, string] {
+export function coinToDecimal(tokens: readonly BankToken[], coin: Coin): readonly [Decimal, string] {
   const match = tokens.find(({ denom }) => denom === coin.denom);
   if (!match) {
     throw Error(`unknown denom: ${coin.denom}`);
@@ -63,7 +63,7 @@ export function coinToDecimal(tokens: BankTokens, coin: Coin): readonly [Decimal
   return [value, match.ticker];
 }
 
-export function decodeAmount(tokens: BankTokens, coin: Coin): Amount {
+export function decodeAmount(tokens: readonly BankToken[], coin: Coin): Amount {
   const [value, ticker] = coinToDecimal(tokens, coin);
   return {
     quantity: value.atomics,
@@ -76,7 +76,7 @@ export function parseMsg(
   msg: types.Msg,
   memo: string | undefined,
   chainId: ChainId,
-  tokens: BankTokens,
+  tokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[],
 ): UnsignedTransaction {
   if (types.isMsgSend(msg)) {
@@ -130,7 +130,7 @@ export function parseMsg(
   }
 }
 
-export function parseFee(fee: types.StdFee, tokens: BankTokens): Fee {
+export function parseFee(fee: types.StdFee, tokens: readonly BankToken[]): Fee {
   if (fee.amount.length !== 1) {
     throw new Error("Only fee with one amount is supported");
   }
@@ -143,7 +143,7 @@ export function parseFee(fee: types.StdFee, tokens: BankTokens): Fee {
 export function parseUnsignedTx(
   txValue: types.StdTx,
   chainId: ChainId,
-  tokens: BankTokens,
+  tokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[],
 ): UnsignedTransaction {
   if (!types.isStdTx(txValue)) {
@@ -167,7 +167,7 @@ export function parseSignedTx(
   txValue: types.StdTx,
   chainId: ChainId,
   nonce: Nonce,
-  tokens: BankTokens,
+  tokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[],
 ): SignedTransaction {
   const [primarySignature] = txValue.signatures.map((signature) => decodeFullSignature(signature, nonce));
@@ -181,7 +181,7 @@ export function parseTxsResponseUnsigned(
   chainId: ChainId,
   currentHeight: number,
   response: IndexedTx,
-  tokens: BankTokens,
+  tokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[],
 ): ConfirmedTransaction<UnsignedTransaction> {
   return {
@@ -198,7 +198,7 @@ export function parseTxsResponseSigned(
   currentHeight: number,
   nonce: Nonce,
   response: IndexedTx,
-  tokens: BankTokens,
+  tokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[],
 ): ConfirmedAndSignedTransaction<UnsignedTransaction> {
   return {

--- a/packages/bcp/src/encode.spec.ts
+++ b/packages/bcp/src/encode.spec.ts
@@ -22,7 +22,7 @@ import {
   toBankCoin,
   toErc20Amount,
 } from "./encode";
-import { BankTokens, Erc20Token } from "./types";
+import { BankToken, Erc20Token } from "./types";
 
 const { fromBase64 } = Encoding;
 
@@ -42,7 +42,7 @@ describe("encode", () => {
     tokenTicker: atom,
   };
   const defaultMemo = "hello cosmos hub";
-  const defaultTokens: BankTokens = [
+  const defaultTokens: readonly BankToken[] = [
     {
       fractionalDigits: 6,
       ticker: "ATOM",

--- a/packages/bcp/src/encode.ts
+++ b/packages/bcp/src/encode.ts
@@ -13,7 +13,7 @@ import {
 import { Secp256k1 } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
 
-import { BankTokens, Erc20Token } from "./types";
+import { BankToken, Erc20Token } from "./types";
 
 const { toBase64 } = Encoding;
 
@@ -40,7 +40,7 @@ export function toErc20Amount(amount: Amount, erc20Token: Erc20Token): string {
   return amount.quantity;
 }
 
-export function toBankCoin(amount: Amount, tokens: BankTokens): Coin {
+export function toBankCoin(amount: Amount, tokens: readonly BankToken[]): Coin {
   const match = tokens.find((token) => token.ticker === amount.tokenTicker);
   if (!match) throw Error(`unknown ticker: ${amount.tokenTicker}`);
   if (match.fractionalDigits !== amount.fractionalDigits) {
@@ -54,7 +54,7 @@ export function toBankCoin(amount: Amount, tokens: BankTokens): Coin {
   };
 }
 
-export function encodeFee(fee: Fee, tokens: BankTokens): types.StdFee {
+export function encodeFee(fee: Fee, tokens: readonly BankToken[]): types.StdFee {
   if (fee.tokens === undefined) {
     throw new Error("Cannot encode fee without tokens");
   }
@@ -81,7 +81,7 @@ export function encodeFullSignature(fullSignature: FullSignature): types.StdSign
 
 export function buildUnsignedTx(
   tx: UnsignedTransaction,
-  bankTokens: BankTokens,
+  bankTokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[] = [],
 ): types.CosmosSdkTx {
   if (!isSendTransaction(tx)) {
@@ -144,7 +144,7 @@ export function buildUnsignedTx(
 
 export function buildSignedTx(
   tx: SignedTransaction,
-  bankTokens: BankTokens,
+  bankTokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[] = [],
 ): types.CosmosSdkTx {
   const built = buildUnsignedTx(tx.transaction, bankTokens, erc20Tokens);

--- a/packages/bcp/src/index.ts
+++ b/packages/bcp/src/index.ts
@@ -1,3 +1,4 @@
 export { CosmWasmCodec } from "./cosmwasmcodec";
 export { CosmWasmConnection, TokenConfiguration } from "./cosmwasmconnection";
 export { createCosmWasmConnector } from "./cosmwasmconnector";
+export { BankToken, Erc20Token } from "./types";

--- a/packages/bcp/src/types.ts
+++ b/packages/bcp/src/types.ts
@@ -15,8 +15,6 @@ export interface BankToken {
   readonly fractionalDigits: number;
 }
 
-export type BankTokens = ReadonlyArray<BankToken>;
-
 export interface Erc20Token {
   readonly contractAddress: string;
   readonly ticker: string;

--- a/packages/bcp/types/cosmwasmcodec.d.ts
+++ b/packages/bcp/types/cosmwasmcodec.d.ts
@@ -10,12 +10,12 @@ import {
   TxCodec,
   UnsignedTransaction,
 } from "@iov/bcp";
-import { BankTokens, Erc20Token } from "./types";
+import { BankToken, Erc20Token } from "./types";
 export declare class CosmWasmCodec implements TxCodec {
   private readonly addressPrefix;
   private readonly bankTokens;
   private readonly erc20Tokens;
-  constructor(addressPrefix: string, bankTokens: BankTokens, erc20Tokens?: readonly Erc20Token[]);
+  constructor(addressPrefix: string, bankTokens: readonly BankToken[], erc20Tokens?: readonly Erc20Token[]);
   bytesToSign(unsigned: UnsignedTransaction, nonce: Nonce): SigningJob;
   bytesToPost(signed: SignedTransaction): PostableBytes;
   identifier(_signed: SignedTransaction): TransactionId;

--- a/packages/bcp/types/decode.d.ts
+++ b/packages/bcp/types/decode.d.ts
@@ -13,38 +13,38 @@ import {
   UnsignedTransaction,
 } from "@iov/bcp";
 import { Decimal } from "@iov/encoding";
-import { BankTokens, Erc20Token } from "./types";
+import { BankToken, Erc20Token } from "./types";
 export declare function decodePubkey(pubkey: types.PubKey): PubkeyBundle;
 export declare function decodeSignature(signature: string): SignatureBytes;
 export declare function decodeFullSignature(signature: types.StdSignature, nonce: number): FullSignature;
-export declare function coinToDecimal(tokens: BankTokens, coin: Coin): readonly [Decimal, string];
-export declare function decodeAmount(tokens: BankTokens, coin: Coin): Amount;
+export declare function coinToDecimal(tokens: readonly BankToken[], coin: Coin): readonly [Decimal, string];
+export declare function decodeAmount(tokens: readonly BankToken[], coin: Coin): Amount;
 export declare function parseMsg(
   msg: types.Msg,
   memo: string | undefined,
   chainId: ChainId,
-  tokens: BankTokens,
+  tokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[],
 ): UnsignedTransaction;
-export declare function parseFee(fee: types.StdFee, tokens: BankTokens): Fee;
+export declare function parseFee(fee: types.StdFee, tokens: readonly BankToken[]): Fee;
 export declare function parseUnsignedTx(
   txValue: types.StdTx,
   chainId: ChainId,
-  tokens: BankTokens,
+  tokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[],
 ): UnsignedTransaction;
 export declare function parseSignedTx(
   txValue: types.StdTx,
   chainId: ChainId,
   nonce: Nonce,
-  tokens: BankTokens,
+  tokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[],
 ): SignedTransaction;
 export declare function parseTxsResponseUnsigned(
   chainId: ChainId,
   currentHeight: number,
   response: IndexedTx,
-  tokens: BankTokens,
+  tokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[],
 ): ConfirmedTransaction<UnsignedTransaction>;
 export declare function parseTxsResponseSigned(
@@ -52,6 +52,6 @@ export declare function parseTxsResponseSigned(
   currentHeight: number,
   nonce: Nonce,
   response: IndexedTx,
-  tokens: BankTokens,
+  tokens: readonly BankToken[],
   erc20Tokens: readonly Erc20Token[],
 ): ConfirmedAndSignedTransaction<UnsignedTransaction>;

--- a/packages/bcp/types/encode.d.ts
+++ b/packages/bcp/types/encode.d.ts
@@ -1,18 +1,18 @@
 import { Coin, types } from "@cosmwasm/sdk";
 import { Amount, Fee, FullSignature, PubkeyBundle, SignedTransaction, UnsignedTransaction } from "@iov/bcp";
-import { BankTokens, Erc20Token } from "./types";
+import { BankToken, Erc20Token } from "./types";
 export declare function encodePubkey(pubkey: PubkeyBundle): types.PubKey;
 export declare function toErc20Amount(amount: Amount, erc20Token: Erc20Token): string;
-export declare function toBankCoin(amount: Amount, tokens: BankTokens): Coin;
-export declare function encodeFee(fee: Fee, tokens: BankTokens): types.StdFee;
+export declare function toBankCoin(amount: Amount, tokens: readonly BankToken[]): Coin;
+export declare function encodeFee(fee: Fee, tokens: readonly BankToken[]): types.StdFee;
 export declare function encodeFullSignature(fullSignature: FullSignature): types.StdSignature;
 export declare function buildUnsignedTx(
   tx: UnsignedTransaction,
-  bankTokens: BankTokens,
+  bankTokens: readonly BankToken[],
   erc20Tokens?: readonly Erc20Token[],
 ): types.CosmosSdkTx;
 export declare function buildSignedTx(
   tx: SignedTransaction,
-  bankTokens: BankTokens,
+  bankTokens: readonly BankToken[],
   erc20Tokens?: readonly Erc20Token[],
 ): types.CosmosSdkTx;

--- a/packages/bcp/types/index.d.ts
+++ b/packages/bcp/types/index.d.ts
@@ -1,3 +1,4 @@
 export { CosmWasmCodec } from "./cosmwasmcodec";
 export { CosmWasmConnection, TokenConfiguration } from "./cosmwasmconnection";
 export { createCosmWasmConnector } from "./cosmwasmconnector";
+export { BankToken, Erc20Token } from "./types";

--- a/packages/bcp/types/types.d.ts
+++ b/packages/bcp/types/types.d.ts
@@ -13,7 +13,6 @@ export interface BankToken {
    */
   readonly fractionalDigits: number;
 }
-export declare type BankTokens = ReadonlyArray<BankToken>;
 export interface Erc20Token {
   readonly contractAddress: string;
   readonly ticker: string;


### PR DESCRIPTION
The types BankToken and Erc20Token are needed to construct a codes without a connection.

BankTokens was removed to avoid maintaining an unnecessary type. Usage was unified with the Erc20Token.