### PR TITLE
Improve hackatom test contract code

### DIFF
--- a/packages/cosmwasm/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.spec.ts
@@ -373,7 +373,7 @@ describe("CosmWasmClient", () => {
         const client = new SigningCosmWasmClient(wasmd.endpoint, alice.address0, (signBytes) =>
           pen.sign(signBytes),
         );
-        const { codeId } = await client.upload(getHackatom());
+        const { codeId } = await client.upload(getHackatom().data);
         const initMsg = { verifier: makeRandomAddress(), beneficiary: makeRandomAddress() };
         const { contractAddress } = await client.instantiate(codeId, initMsg, "random hackatom");
         contract = { initMsg: initMsg, address: contractAddress };
@@ -426,7 +426,7 @@ describe("CosmWasmClient", () => {
         const client = new SigningCosmWasmClient(wasmd.endpoint, alice.address0, (signBytes) =>
           pen.sign(signBytes),
         );
-        const { codeId } = await client.upload(getHackatom());
+        const { codeId } = await client.upload(getHackatom().data);
         const initMsg = { verifier: makeRandomAddress(), beneficiary: makeRandomAddress() };
         const { contractAddress } = await client.instantiate(codeId, initMsg, "a different hackatom");
         contract = { initMsg: initMsg, address: contractAddress };

--- a/packages/cosmwasm/src/restclient.spec.ts
+++ b/packages/cosmwasm/src/restclient.spec.ts
@@ -33,6 +33,7 @@ import cosmoshub from "./testdata/cosmoshub.json";
 import {
   alice,
   bech32AddressMatcher,
+  ContractUploadInstructions,
   deployedErc20,
   fromOneElementArray,
   getHackatom,
@@ -60,15 +61,19 @@ function makeSignedTx(firstMsg: Msg, fee: StdFee, memo: string, firstSignature: 
   };
 }
 
-async function uploadContract(client: RestClient, pen: Pen, wasmCode: Uint8Array): Promise<PostTxsResponse> {
+async function uploadContract(
+  client: RestClient,
+  pen: Pen,
+  contract: ContractUploadInstructions,
+): Promise<PostTxsResponse> {
   const memo = "My first contract on chain";
   const theMsg: MsgStoreCode = {
     type: "wasm/store-code",
     value: {
       sender: alice.address0,
-      wasm_byte_code: toBase64(wasmCode),
-      source: "https://github.com/confio/cosmwasm/raw/0.7/lib/vm/testdata/contract_0.6.wasm",
-      builder: "confio/cosmwasm-opt:0.6.2",
+      wasm_byte_code: toBase64(contract.data),
+      source: contract.source || "",
+      builder: contract.builder || "",
     },
   };
   const fee: StdFee = {
@@ -1199,8 +1204,8 @@ describe("RestClient", () => {
       const numExisting = existingInfos.length;
 
       // upload data
-      const wasmCode = getHackatom();
-      const result = await uploadContract(client, pen, wasmCode);
+      const hackatom = getHackatom();
+      const result = await uploadContract(client, pen, hackatom);
       expect(result.code).toBeFalsy();
       const logs = parseLogs(result.logs);
       const codeIdAttr = findAttribute(logs, "message", "code_id");
@@ -1214,18 +1219,16 @@ describe("RestClient", () => {
       expect(lastInfo.creator).toEqual(alice.address0);
 
       // ensure metadata is present
-      expect(lastInfo.source).toEqual(
-        "https://github.com/confio/cosmwasm/raw/0.7/lib/vm/testdata/contract_0.6.wasm",
-      );
-      expect(lastInfo.builder).toEqual("confio/cosmwasm-opt:0.6.2");
+      expect(lastInfo.source).toEqual(hackatom.source);
+      expect(lastInfo.builder).toEqual(hackatom.builder);
 
       // check code hash matches expectation
-      const wasmHash = new Sha256(wasmCode).digest();
+      const wasmHash = new Sha256(hackatom.data).digest();
       expect(lastInfo.data_hash.toLowerCase()).toEqual(toHex(wasmHash));
 
       // download code and check against auto-gen
       const { data } = await client.getCode(codeId);
-      expect(fromBase64(data)).toEqual(wasmCode);
+      expect(fromBase64(data)).toEqual(hackatom.data);
     });
 
     it("can list contracts and get info", async () => {

--- a/packages/cosmwasm/src/restclient.spec.ts
+++ b/packages/cosmwasm/src/restclient.spec.ts
@@ -60,11 +60,7 @@ function makeSignedTx(firstMsg: Msg, fee: StdFee, memo: string, firstSignature: 
   };
 }
 
-async function uploadCustomContract(
-  client: RestClient,
-  pen: Pen,
-  wasmCode: Uint8Array,
-): Promise<PostTxsResponse> {
+async function uploadContract(client: RestClient, pen: Pen, wasmCode: Uint8Array): Promise<PostTxsResponse> {
   const memo = "My first contract on chain";
   const theMsg: MsgStoreCode = {
     type: "wasm/store-code",
@@ -90,10 +86,6 @@ async function uploadCustomContract(
   const signature = await pen.sign(signBytes);
   const signedTx = makeSignedTx(theMsg, fee, memo, signature);
   return client.postTx(signedTx);
-}
-
-async function uploadContract(client: RestClient, pen: Pen): Promise<PostTxsResponse> {
-  return uploadCustomContract(client, pen, getHackatom());
 }
 
 async function instantiateContract(
@@ -1144,7 +1136,7 @@ describe("RestClient", () => {
       // upload
       {
         // console.log("Raw log:", result.raw_log);
-        const result = await uploadContract(client, pen);
+        const result = await uploadContract(client, pen, getHackatom());
         expect(result.code).toBeFalsy();
         const logs = parseLogs(result.logs);
         const codeIdAttr = findAttribute(logs, "message", "code_id");
@@ -1208,7 +1200,7 @@ describe("RestClient", () => {
 
       // upload data
       const wasmCode = getHackatom();
-      const result = await uploadCustomContract(client, pen, wasmCode);
+      const result = await uploadContract(client, pen, wasmCode);
       expect(result.code).toBeFalsy();
       const logs = parseLogs(result.logs);
       const codeIdAttr = findAttribute(logs, "message", "code_id");
@@ -1254,7 +1246,7 @@ describe("RestClient", () => {
       if (existingInfos.length > 0) {
         codeId = existingInfos[existingInfos.length - 1].id;
       } else {
-        const uploadResult = await uploadContract(client, pen);
+        const uploadResult = await uploadContract(client, pen, getHackatom());
         expect(uploadResult.code).toBeFalsy();
         const uploadLogs = parseLogs(uploadResult.logs);
         const codeIdAttr = findAttribute(uploadLogs, "message", "code_id");
@@ -1308,7 +1300,7 @@ describe("RestClient", () => {
       beforeAll(async () => {
         if (wasmdEnabled()) {
           const pen = await Secp256k1Pen.fromMnemonic(alice.mnemonic);
-          const uploadResult = await uploadContract(client, pen);
+          const uploadResult = await uploadContract(client, pen, getHackatom());
           assert(!uploadResult.code);
           const uploadLogs = parseLogs(uploadResult.logs);
           const codeId = Number.parseInt(findAttribute(uploadLogs, "message", "code_id").value, 10);

--- a/packages/cosmwasm/src/signingcosmwasmclient.spec.ts
+++ b/packages/cosmwasm/src/signingcosmwasmclient.spec.ts
@@ -42,7 +42,7 @@ describe("SigningCosmWasmClient", () => {
       pendingWithoutWasmd();
       const pen = await Secp256k1Pen.fromMnemonic(alice.mnemonic);
       const client = new SigningCosmWasmClient(httpUrl, alice.address0, (signBytes) => pen.sign(signBytes));
-      const wasm = getHackatom();
+      const wasm = getHackatom().data;
       const {
         codeId,
         originalChecksum,
@@ -61,13 +61,13 @@ describe("SigningCosmWasmClient", () => {
       pendingWithoutWasmd();
       const pen = await Secp256k1Pen.fromMnemonic(alice.mnemonic);
       const client = new SigningCosmWasmClient(httpUrl, alice.address0, (signBytes) => pen.sign(signBytes));
-      const wasm = getHackatom();
+      const hackatom = getHackatom();
 
       const meta: UploadMeta = {
         source: "https://crates.io/api/v1/crates/cw-nameservice/0.1.0/download",
         builder: "confio/cosmwasm-opt:0.6.2",
       };
-      const { codeId } = await client.upload(wasm, meta);
+      const { codeId } = await client.upload(hackatom.data, meta);
 
       const codeDetails = await client.getCodeDetails(codeId);
       expect(codeDetails.source).toEqual(meta.source);
@@ -80,7 +80,7 @@ describe("SigningCosmWasmClient", () => {
       pendingWithoutWasmd();
       const pen = await Secp256k1Pen.fromMnemonic(alice.mnemonic);
       const client = new SigningCosmWasmClient(httpUrl, alice.address0, (signBytes) => pen.sign(signBytes));
-      const { codeId } = await client.upload(getHackatom());
+      const { codeId } = await client.upload(getHackatom().data);
 
       const transferAmount: readonly Coin[] = [
         {
@@ -113,7 +113,7 @@ describe("SigningCosmWasmClient", () => {
       pendingWithoutWasmd();
       const pen = await Secp256k1Pen.fromMnemonic(alice.mnemonic);
       const client = new SigningCosmWasmClient(httpUrl, alice.address0, (signBytes) => pen.sign(signBytes));
-      const { codeId } = await client.upload(getHackatom());
+      const { codeId } = await client.upload(getHackatom().data);
 
       const contractAddress1 = await client.instantiate(
         codeId,
@@ -140,7 +140,7 @@ describe("SigningCosmWasmClient", () => {
       pendingWithoutWasmd();
       const pen = await Secp256k1Pen.fromMnemonic(alice.mnemonic);
       const client = new SigningCosmWasmClient(httpUrl, alice.address0, (signBytes) => pen.sign(signBytes));
-      const { codeId } = await client.upload(getHackatom());
+      const { codeId } = await client.upload(getHackatom().data);
 
       // instantiate
       const transferAmount: readonly Coin[] = [

--- a/packages/cosmwasm/src/testutils.spec.ts
+++ b/packages/cosmwasm/src/testutils.spec.ts
@@ -3,8 +3,20 @@ import { Bech32, fromBase64 } from "@iov/encoding";
 
 import hackatom from "./testdata/contract.json";
 
-export function getHackatom(): Uint8Array {
-  return fromBase64(hackatom.data);
+/** An internal testing type. SigningCosmWasmClient has a similar but different interface */
+export interface ContractUploadInstructions {
+  /** The wasm bytecode */
+  readonly data: Uint8Array;
+  readonly source?: string;
+  readonly builder?: string;
+}
+
+export function getHackatom(): ContractUploadInstructions {
+  return {
+    data: fromBase64(hackatom.data),
+    source: "https://some.registry.nice/project/raw/0.7/lib/vm/testdata/contract_0.6.wasm.blub.tar.gz",
+    builder: "confio/cosmwasm-opt:12.34.56",
+  };
 }
 
 export function makeRandomAddress(): string {


### PR DESCRIPTION
- Reduce `uploadCustomContract`/`uploadContract` to just one function to make visible in the test which contract we is uploaded
- Add meta data to `getHackatom()` to avoid spreading it all over the place